### PR TITLE
feat(client): Show server error messages

### DIFF
--- a/packages/client/src/modules/ListRecords.tsx
+++ b/packages/client/src/modules/ListRecords.tsx
@@ -1,16 +1,49 @@
 import * as React from 'react'
 import { RemoteData, cata } from 'remote-data-ts'
+import styled from 'styled-components'
 
 import SearchResult from '../components/SearchResult'
 import { FormattedFunctionRecord } from '../types'
+import { SearchError, fold } from '../services/SearchError'
+
+const Flex = styled.div({
+  display: 'flex',
+  flexWrap: 'wrap',
+})
+
+const Pre = styled.pre({
+  margin: 0,
+  marginLeft: 10,
+})
 
 const key = ({ location }: FormattedFunctionRecord) =>
   `${location.path}-${location.lines.from}-${location.lines.to}`
 
-const renderData = cata<FormattedFunctionRecord[], string, React.ReactNode>({
+const renderData = cata<
+  FormattedFunctionRecord[],
+  SearchError,
+  React.ReactNode
+>({
   notAsked: () => <span>Search for functions by name, types or signature</span>,
   loading: () => <span>loading ...</span>,
-  failure: e => <span>{e}</span>,
+  failure: e =>
+    fold({
+      MissingQuery: () => <span>Missing query</span>,
+      InvalidQuery: reason => (
+        <Flex>
+          <p>Invalid Query: </p>
+          <p>
+            <Pre>
+              Error on{' '}
+              {// First line of the error is: // '(line 1, column 5)'
+              reason.replace(/line \d, /, '')}
+            </Pre>
+          </p>
+        </Flex>
+      ),
+      FetchError: msg => <span>{msg}</span>,
+      UnknownError: () => <span>Something went wrong :(</span>,
+    })(e),
   success: results =>
     results.length ? (
       results.map(r => <SearchResult key={key(r)} result={r} />)
@@ -19,8 +52,10 @@ const renderData = cata<FormattedFunctionRecord[], string, React.ReactNode>({
     ),
 })
 
+type RecordsResult = RemoteData<FormattedFunctionRecord[], SearchError>
+
 interface Props {
-  records: RemoteData<FormattedFunctionRecord[], string>
+  records: RecordsResult
 }
 
 const Results: React.SFC<Props> = ({ records }) => (

--- a/packages/client/src/services/SearchError.ts
+++ b/packages/client/src/services/SearchError.ts
@@ -1,0 +1,41 @@
+export type SearchError =
+  // Client Errors - 400 code
+  | { tag: 'InvalidQuery'; contents: string }
+  | { tag: 'MissingQuery' }
+  // Other Errors (e.g. network down, server error !== 400)
+  | { tag: 'FetchError'; message: string }
+  | { tag: 'UnknownError' }
+
+export const invalidQuery = (contents: string): SearchError => ({
+  tag: 'InvalidQuery',
+  contents,
+})
+
+export const missingQuery = (): SearchError => ({ tag: 'MissingQuery' })
+
+export const fetchError = (message: string): SearchError => ({
+  tag: 'FetchError',
+  message,
+})
+
+export const unknownError = (): SearchError => ({ tag: 'UnknownError' })
+
+interface Handler<R> {
+  InvalidQuery: (contents: string) => R
+  MissingQuery: () => R
+  FetchError: (message: string) => R
+  UnknownError: () => R
+}
+
+export const fold = <R>(handler: Handler<R>) => (fa: SearchError): R => {
+  if (fa.tag === 'InvalidQuery') {
+    return handler.InvalidQuery(fa.contents)
+  }
+  if (fa.tag === 'MissingQuery') {
+    return handler.MissingQuery()
+  }
+  if (fa.tag === 'FetchError') {
+    return handler.FetchError(fa.message)
+  }
+  return handler.UnknownError()
+}


### PR DESCRIPTION
Show server errors

- Invalid query (with message)
- Missing query (client shouldn't send request without query but ...)
- Fetch error (e.g. no network or 500)
- Unknown error (some 💩 went wrong)