### PR TITLE
Simplify nix

### DIFF
--- a/api-lib/default.nix
+++ b/api-lib/default.nix
@@ -1,2 +1,0 @@
-{ pkgs, ... }:
-  pkgs.haskell.packages.ghc922.callCabal2nix "tsearch-api-lib" ./. {}

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,11 @@
         inherit system;
         config.allowBroken = true;
       };
-      server = import ./server/. pkgs;
+      ghc = import ./nix/override-ghc.nix pkgs.haskell.packages.ghc922;
+      server = ghc.callCabal2nix "server" ./server/. {};
     in {
       devShell = import ./shell.nix {
-        inherit pkgs;
+        inherit pkgs server;
       };
       defaultPackage = server;
       packages = flake-utils.lib.flattenTree {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,6 +1,0 @@
-{pkgs, ...}:
-  pkgs.haskell.packages.ghc922.override {
-    overrides = final: prev: rec {
-      tsearch-api-lib = import ../api-lib/. pkgs;
-    };
-  }

--- a/nix/override-ghc.nix
+++ b/nix/override-ghc.nix
@@ -1,0 +1,5 @@
+ghc: ghc.override {
+    overrides = final: prev: rec {
+      tsearch-api-lib = final.callCabal2nix "tsearch-api-lib" ../api-lib/. {};
+    };
+  }

--- a/server/default.nix
+++ b/server/default.nix
@@ -1,4 +1,1 @@
-{pkgs, ...}: let
-  myHaskell = pkgs.callPackage ../nix/haskell.nix {};
-in
-  myHaskell.callCabal2nix "server" ../server/. {}
+ghc: ghc.callCabal2nix "server" ./. {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,11 @@
 {
   pkgs,
+  server,
   ...
 }:
 pkgs.mkShell {
   inputsFrom = [
-    (import ./server/. pkgs).env
+    server.env
   ];
   buildInputs = with pkgs; [
     haskell-language-server


### PR DESCRIPTION
You can add the default.nix back to each project later on if you want and simply import them in
override-ghc.nix instead of calling them directly from that file if things gets more complicated.